### PR TITLE
Changes to prevent locking the player

### DIFF
--- a/library/src/main/java/org/antennapod/audio/SonicAudioPlayer.java
+++ b/library/src/main/java/org/antennapod/audio/SonicAudioPlayer.java
@@ -520,10 +520,22 @@ public class SonicAudioPlayer extends AbstractAudioPlayer {
         mLock.lock();
         mExtractor = new MediaExtractor();
         if (mPath != null) {
-            mExtractor.setDataSource(mPath);
+            try {
+                mExtractor.setDataSource(mPath);
+            } catch (Exception e) {
+                mLock.unlock();
+                throw e;
+            }
+
         } else if (mUri != null) {
-            mExtractor.setDataSource(mContext, mUri, null);
+            try {
+                mExtractor.setDataSource(mContext, mUri, null);
+            } catch (Exception e) {
+                mLock.unlock();
+                throw e;
+            }
         } else {
+            mLock.unlock();
             throw new IOException();
         }
 
@@ -539,6 +551,7 @@ public class SonicAudioPlayer extends AbstractAudioPlayer {
         }
 
         if(trackNum < 0) {
+            mLock.unlock();
             throw new IOException("No audio track found");
         }
 


### PR DESCRIPTION
To test the situation that motivated these changes, just try to play an episode by streaming without an internet connection. The player can't reset to play another episode until the lock have been released.
