### PR TITLE
Changes to allow seeking without locking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.1'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 24
+    buildToolsVersion "24.0.1"
+
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0.14"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 23
     buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0.14"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,11 +2,11 @@ apply plugin: "com.android.library"
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 24
+        minSdkVersion 16
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0.14"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0.14"
     }

--- a/library/src/main/java/org/antennapod/audio/SonicAudioPlayer.java
+++ b/library/src/main/java/org/antennapod/audio/SonicAudioPlayer.java
@@ -29,6 +29,7 @@ import android.media.MediaExtractor;
 import android.media.MediaFormat;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Handler;
 import android.os.PowerManager;
 import android.util.Log;
 
@@ -384,8 +385,8 @@ public class SonicAudioPlayer extends AbstractAudioPlayer {
 
                 final boolean wasPlaying = playing;
 
-                // the seeking is started in another thread to prevent UI locking
-                Thread t = new Thread(new Runnable() {
+                Runnable seekRunnable = new Runnable() {
+
                     @Override
                     public void run() {
                         String lastPath = currentPath();
@@ -416,10 +417,18 @@ public class SonicAudioPlayer extends AbstractAudioPlayer {
                             }
                         }
                     }
-                });
+                };
 
-                t.setDaemon(true);
-                t.start();
+                // the seeking is started in another thread to prevent UI locking
+                if (mUri != null) {
+                    Thread t = new Thread(seekRunnable);
+
+                    t.setDaemon(true);
+                    t.start();
+                }
+                else {
+                    seekRunnable.run();
+                }
 
                 break;
             default:


### PR DESCRIPTION
Today, if you try to seek to another position in a streaming episode, the library prevents you from changing to another episode.

I have tried to follow the same logic that we used in "initStream" method.
